### PR TITLE
Basic paginated display of users

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -228,6 +228,7 @@ DJANGO_APPS = (
 LOCAL_APPS = (
     'core',
     'courses',
+    'users',
     'django_rjs',
     'help',
     'soapbox',

--- a/analytics_dashboard/static/js/load/init-models.js
+++ b/analytics_dashboard/static/js/load/init-models.js
@@ -8,14 +8,12 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
         'use strict';
         var courseModel = new CourseModel(),
             trackingModel = new TrackingModel(),
-            userModel = new UserModel();
+            userModel = new UserModel(),
+            modelData = window.initModelData || {}; // initModelData is set by the Django template at render time.
 
-        /* jshint ignore:start */
-        // initModelData is set by the Django template at render time.
-        courseModel.set(initModelData.course);
-        trackingModel.set(initModelData.tracking);
-        userModel.set(initModelData.user);
-        /* jshint ignore:end */
+        courseModel.set(modelData.course);
+        trackingModel.set(modelData.tracking);
+        userModel.set(modelData.user);
 
         return {
             courseModel: courseModel,

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -265,23 +265,72 @@ $lens-box-model: border-box;
   }
 }
 
-.course-list {
+.pagination-nav {
+  @include clearfix();
+
+  text-align: right;
+  padding-right: $padding-large-horizontal;
+
+  .nav {
+    width: 100%;
+  }
+
+  .nav li {
+    display: inline-block;
+    float: none;
+  }
+
+  .pagination-status {
+    padding: 0 10px;
+  }
+
+  .unavailable-page {
+    visibility: hidden;
+  }
+
+  li > a {
+    color: $link-color;
+    padding-top: 0px;
+    padding-bottom: $padding-small-vertical;
+
+    &:hover {
+      color: $link-hover-color;
+      background-color: transparent;
+    }
+  }
+}
+
+.pagination-nav + .paginated {
+  margin-top: 0;
+}
+
+.paginated + .pagination-nav {
+  margin-top: -15px;
+  margin-bottom: 15px;
+
+  li > a {
+    padding-top: $padding-small-vertical;
+    padding-bottom: 0;
+  }
+}
+
+.course-list, .user-list {
   margin-top: 10px;
   margin-bottom: 15px;
   background: white;
   border: 1px solid $edx-gray;
   border-width: 0 0 1px 1px;
 
-  .course {
+  .course, .user {
     padding: 15px;
     border: 1px solid $edx-gray;
     border-width: 1px 1px 0 0;
 
-    .course-name {
+    .course-name, .main-info {
       font-size: $font-size-large;
     }
 
-    .course-key {
+    .course-key, .sub-info {
       color: $edx-gray;
     }
   }
@@ -315,6 +364,12 @@ body.view-course-list {
       font-size: $font-size-small;
       margin-bottom: 50px;
     }
+  }
+}
+
+.user-profile-info {
+  .missing-data {
+    color: $edx-gray-l1;
   }
 }
 

--- a/analytics_dashboard/templates/pagination.html
+++ b/analytics_dashboard/templates/pagination.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<div class="pagination-nav">
+    <ul class="nav navbar-nav">
+        <li {% if page <= 1 %} class="unavailable-page" aria-hidden="true"{% endif %}>
+        	<a href="?page={{page|add:-1}}">{% trans "Prev" %}</a>
+        </li>
+        <li class="pagination-status">{% blocktrans %}Page {{page}} of {{total_pages}}{% endblocktrans %}</li>
+        <li {% if page >= total_pages %} class="unavailable-page" aria-hidden="true"{% endif %}>
+        	<a href="?page={{page|add:1}}">{% trans "Next" %}</a>
+        </li>
+    </ul>
+</div>

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -25,6 +25,7 @@ urlpatterns = patterns(
     url(r'^status/$', views.status, name='status'),
     url(r'^health/$', views.health, name='health'),
     url(r'^courses/', include('courses.urls', namespace='courses')),
+    url(r'^users/', include('users.urls', namespace='users')),
     url(r'^admin/', include(admin.site.urls)),
     url('', include('social.apps.django_app.urls', namespace='social')),
     url(r'^accounts/login/$',

--- a/analytics_dashboard/users/templates/users/api-error.html
+++ b/analytics_dashboard/users/templates/users/api-error.html
@@ -1,0 +1,16 @@
+{% extends "base-error.html" %}
+{% load i18n %}
+
+{% comment %}Translators: This message is displayed when the website is unable to retrieve data requested by the user{% endcomment %}
+{% block title %}{% trans "Data Retrieval Failed" %} {{ block.super }}{% endblock title %}
+
+{% block error-title %}{% trans "Data Retrieval Failed" %}{% endblock %}
+{% block error-copy %}
+  {% trans "There was a problem retrieving the data you requested. Please try again. If you continue to experience issues, please let us know." %}
+{% endblock %}
+
+{% block buttons %}
+  <a onclick="location.reload(true);" class="btn btn-lg btn-primary"> <i class="ico fa fa-refresh" aria-hidden="true"></i>
+    {% trans "Try Again" %}</a>
+  {{ block.super }}
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/base.html
+++ b/analytics_dashboard/users/templates/users/base.html
@@ -1,0 +1,20 @@
+{% extends "base_dashboard.html" %}
+{% load dashboard_extras %}
+
+{% block title %}{{ page_title }} - {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+{% endblock %}
+
+{% block content %}
+  {% block child_content %}
+  {% endblock %}
+  {% block data_messaging %}
+    {% if update_message %}
+      <div class="data-update-message">{{ update_message }}</div>
+    {% endif %}
+    {% if data_information_message %}
+      <div class="data-information-message">{{ data_information_message }}</div>
+    {% endif %}
+  {% endblock %}
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/list.html
+++ b/analytics_dashboard/users/templates/users/list.html
@@ -1,0 +1,55 @@
+{% extends "users/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load dashboard_extras %}
+{% load firstof from future %}
+
+{% block view-name %}view-course-list{% endblock view-name %}
+
+{% block title %}{% trans "Users" %} {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans %}Registered Users{% endblocktrans %}
+  </h3>
+{% endblock %}
+
+{% block intro-text %}
+  {% blocktrans %}Here are all the registered users in the system:{% endblocktrans %}
+{% endblock intro-text %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-8">
+
+      {% include "pagination.html" %}
+
+      <div class="user-list paginated">
+        {% for user in users %}
+          <div class="user">
+            <a href="{% url 'users:profile' user_id=user.id %}">
+              <span class="main-info">{{user.username}}</span>
+            </a>
+            <div class="sub-info">{{user.name}}</div>
+          </div>
+        {% endfor %}
+      </div>
+
+      {% include "pagination.html" %}
+
+    </div>
+
+    <div class="col-md-4">
+      <div class="help-msg">
+        <h4>{% blocktrans %}New to {{ application_name }}?{% endblocktrans %}</h4>
+
+        {% captureas email_link %}
+          <a class="feedback-email" href="mailto:{{ feedback_email }}?Subject=Feedback">
+            {{ feedback_email }}</a>{% endcaptureas %}
+
+        <p class="info-text">{% blocktrans trimmed %} Click Help in the upper-right corner to get more information
+          about {{ application_name }}. Send us feedback at {{ email_link }}.{% endblocktrans %}</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/profile.html
+++ b/analytics_dashboard/users/templates/users/profile.html
@@ -1,0 +1,45 @@
+{% extends "users/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load dashboard_extras %}
+{% load firstof from future %}
+
+{% block view-name %}view-course-list{% endblock view-name %}
+
+{% block title %}{{ profile.name }} {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans with name=profile.name %}User Profile: {{name}}{% endblocktrans %}
+  </h3>
+{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-xs-12 col-md-8">
+      <table class="table user-profile-info">
+        <tr><td>{% trans "Name" %}</td><td> {{profile.name}}</td></tr>
+        <tr><td>{% trans "Username" %}</td><td> {{profile.username}}</td></tr>
+        <tr><td>{% trans "Email" %}</td><td> {{profile.email}}</td></tr>
+        <tr><td>{% trans "Last Login" %}</td><td> {{profile.last_login|date:"DATETIME_FORMAT"}}</td></tr>
+        <tr><td>{% trans "Date Joined" %}</td><td> {{profile.date_joined|date:"DATETIME_FORMAT"}}</td></tr>
+        <tr>
+          <td>{% trans "Staff Status" %}</td>
+          <td>{%if profile.is_staff%}{%trans "Yes"%}{%else%}{%trans "No"%}{%endif%}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Gender" %}</td>
+          {% if profile.gender == constants.gender.UNKNOWN %}<td class="missing-data">{% trans "Unknown" %}</td>{%else%}<td>{{profile.gender}}</td>{%endif%}
+        </tr>
+        <tr>
+          <td>{% trans "Year of Birth" %}</td>
+          {% if not profile.year_of_birth %}<td class="missing-data">{% trans "Unknown" %}</td>{%else%}<td>{{profile.year_of_birth}}</td>{%endif%}
+        </tr>
+        <tr>
+          <td>{% trans "Level of Education" %}</td>
+          {% if profile.gender == constants.education_level.UNKNOWN %}<td class="missing-data">{% trans "Unknown" %}</td>{%else%}<td>{{profile.level_of_education}}</td>{%endif%}
+        </tr>
+      </table>
+    </div>
+  </div>
+{% endblock %}

--- a/analytics_dashboard/users/urls.py
+++ b/analytics_dashboard/users/urls.py
@@ -1,0 +1,11 @@
+# pylint: disable=no-value-for-parameter
+
+from django.conf.urls import url, patterns
+
+from users import views
+
+urlpatterns = patterns(
+    '',
+    url(r'^$', views.UserListView.as_view(), name='list'),
+    url(r'^(?P<user_id>\d+)/$', views.UserProfileView.as_view(), name='profile'),
+)

--- a/analytics_dashboard/users/views/__init__.py
+++ b/analytics_dashboard/users/views/__init__.py
@@ -1,0 +1,2 @@
+from .users import UserListView
+from .profile import UserProfileView

--- a/analytics_dashboard/users/views/base.py
+++ b/analytics_dashboard/users/views/base.py
@@ -1,0 +1,25 @@
+from analyticsclient.client import Client
+from analyticsclient.exceptions import ClientError
+from braces.views import LoginRequiredMixin
+from django.conf import settings
+from django import shortcuts
+from django.views.generic import TemplateView
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class UsersView(LoginRequiredMixin, TemplateView):
+    client = None
+
+    def dispatch(self, request, *args, **kwargs):
+        self.client = Client(
+            base_url=settings.DATA_API_URL,
+            auth_token=settings.DATA_API_AUTH_TOKEN,
+            timeout=5
+        )
+        try:
+            return super(UsersView, self).dispatch(request, *args, **kwargs)
+        except ClientError as e:
+            logger.error('API ClientError: %s (%s)', e, e.message)
+            return shortcuts.render(request, "users/api-error.html")

--- a/analytics_dashboard/users/views/profile.py
+++ b/analytics_dashboard/users/views/profile.py
@@ -1,0 +1,28 @@
+import analyticsclient.constants
+import dateutil.parser
+from django.http import Http404
+
+from .base import UsersView
+
+
+class UserProfileView(UsersView):
+    template_name = 'users/profile.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(UserProfileView, self).get_context_data(**kwargs)
+
+        # TODO: Check permissions of self.request.user
+
+        try:
+            user_id = int(kwargs['user_id'])
+        except ValueError:
+            raise Http404
+
+        response = self.client.users(user_id).profile()
+        for date_field in ('last_login', 'date_joined'):
+            if response[date_field]:
+                response[date_field] = dateutil.parser.parse(response[date_field])
+        context['profile'] = response
+        context['constants'] = analyticsclient.constants
+
+        return context

--- a/analytics_dashboard/users/views/users.py
+++ b/analytics_dashboard/users/views/users.py
@@ -1,0 +1,31 @@
+from __future__ import division
+from django.http import Http404
+import math
+
+from .base import UsersView
+
+
+class UserListView(UsersView):
+    template_name = 'users/list.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(UserListView, self).get_context_data(**kwargs)
+
+        # TODO: Check permissions of self.request.user
+
+        users_per_page = 100
+        try:
+            page = int(self.request.GET.get('page', 1))
+            if page < 1:
+                raise ValueError
+        except ValueError:
+            raise Http404
+
+        response = self.client.user_list().list_users(page=page, limit=users_per_page)
+        users_count = response['count']
+        context['count'] = users_count
+        context['page'] = page
+        context['total_pages'] = int(math.ceil(users_count / users_per_page))
+        context['users'] = response['results']
+
+        return context

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ django-libsass==0.2			# BSD
 django-model-utils==1.5.0 	# BSD
 django-soapbox==1.1         # BSD
 django-waffle==0.10			# BSD
+python-dateutil==2.4.2      # BSD
 
 # other versions cause a segment fault when running compression
 libsass==0.5.1              # MIT


### PR DESCRIPTION
This adds new pages to the dashboard app that can display a list of all users as well as details of any given user.

There is some uncertainty about how this is going to work in the end, so for now I have not included:
- navigation links to these new views
-  tests
- permissions checks

Ticket: [OC-779](https://tasks.opencraft.com/browse/OC-779)
#### Screenshots:

![screen shot 2015-07-11 at 3 59 45 pm](https://cloud.githubusercontent.com/assets/945577/8635690/f07bf55e-27e5-11e5-9f71-5f4b4908d00b.png)
and
![screen shot 2015-07-11 at 4 00 06 pm](https://cloud.githubusercontent.com/assets/945577/8635691/f2ced9fc-27e5-11e5-98fc-0afb2a5466e8.png)
#### Test instructions:

Check out [the related analytics-data-api-client work](https://github.com/open-craft/edx-analytics-data-api-client/pull/1) using git in the `~/apps/data-api-client` folder on the devstack). Then you'll need to install that into the dashboard's virtualenv. To do that (on the devstack as the `analytics` user) use these commands:

```
cd data-api-client/
deactivate
source ~/venvs/dashboard/bin/activate
pip install -e .
```

Now, make sure the LMS, the dashboard, and the data API are all running. Go to http://192.168.33.11:9999/users/ to see the new functionality.
